### PR TITLE
Add give-held easy sign option

### DIFF
--- a/commands.msa
+++ b/commands.msa
@@ -71,6 +71,24 @@
 		)
 	),
 	array(
+		name: 'give-held',
+		params: '<qty> [<slot>]',
+		docs: 'Gives the player a duplicate of your currently held item',
+		code: closure(@args,
+			if(array_size(@args) != 1 && array_size(@args) != 2){
+				die(color(RED).'Usage: /easy-sign give-held qty [slot]')
+			}
+			if(!is_integral(@args[0])){
+				die(color(RED).'Qty must be an integer')
+			}
+			@slot = null
+			if(array_size(@args) == 2){
+				@slot = @args[1]
+			}
+			execute(array(item: pinv(player(), null), qty: @args[0], slot: @slot), @standardSignUsage)
+		)
+	),
+	array(
 		name: 'hunger',
 		params: '',
 		docs: 'Refills a player\'s hunger bar',

--- a/main.ms
+++ b/main.ms
@@ -39,6 +39,26 @@ bind(player_interact, null, null, @e,
 						} else {
 							pgive_item(@item, @qty)
 						}
+					,'give-held',
+						@item = @data['item']
+						@qty = @data['qty']
+						@slot = @data['slot']
+						if(@slot != null){
+							@array = associative_array()
+							@array[@slot] = @item
+							set_pinv(@array)
+						} else {
+							#find empty slot
+							foreach(0..31, @i,
+								if(pinv(player(), @i) == null){
+									# found it
+									@array = associative_array()
+									@array[@i] = @item
+									set_pinv(player(), @array)
+									break()
+								}
+							)
+						}
 					,'hunger',
 						set_phunger(20)
 						set_psaturation(20),


### PR DESCRIPTION
`give-held` easy sign allows for giving an exact duplicate of a specific
item, including named, enchanted, custom lore, etc. items as well as just
duplicating any item that can be held.
